### PR TITLE
Fix Windows build of file_router example

### DIFF
--- a/example/file_router/file_router.cpp
+++ b/example/file_router/file_router.cpp
@@ -154,7 +154,7 @@ main(int argc, char **argv)
         fs::path exec = argv[0];
         exec = exec.filename();
         std::cerr
-            << "Usage: " << exec.c_str()
+            << "Usage: " << exec
             << " <target> <prefix> <doc_root>\n"
                "target: path to make a request\n"
                "prefix: url prefix\n"


### PR DESCRIPTION
On Windows, fs::path::c_str() returns wchar_t const* so cannot be streamed to std::cout. fs::path is output streamable anyway (it might quote it, but that should be fine).